### PR TITLE
SARibbonContextCategory has no method name "compare"

### DIFF
--- a/src/PySARibbon/SARibbonBar.py
+++ b/src/PySARibbon/SARibbonBar.py
@@ -572,9 +572,10 @@ class SARibbonBar(QMenuBar):
 
     def raiseCategory(self, category: SARibbonCategory):
         """确保标签显示出来，tab并切换到对应页"""
-        index = self.m_d.stackedContainerWidget.indexOf(category)
-        if index >= 0:
-            self.setCurrentIndex(index)
+        for i in range(self.m_d.ribbonTabBar.count()):
+            tabData: _SARibbonTabData = self.m_d.ribbonTabBar.tabData(i)
+            if tabData and tabData.category == category:
+                self.setCurrentIndex(i)
 
     def isTwoRowStyle(self) -> bool:
         """判断当前的样式是否为两行"""

--- a/src/PySARibbon/SARibbonBar.py
+++ b/src/PySARibbon/SARibbonBar.py
@@ -435,7 +435,7 @@ class SARibbonBar(QMenuBar):
         """隐藏上下文标签"""
         ishide = False
         for i, category in enumerate(self.m_d.currentShowingContextCategory):
-            if context.compare(category.contextCategory):
+            if context == category.contextCategory:
                 indexs = category.tabPageIndex
                 for index in reversed(indexs):
                     self.m_d.ribbonTabBar.removeTab(index)

--- a/src/PySARibbon/SAWindowButtonGroup.py
+++ b/src/PySARibbon/SAWindowButtonGroup.py
@@ -206,15 +206,15 @@ class SAWindowButtonGroup(QWidget):
         x = 0
         if self.buttonMinimize:
             w = (self.mMinStretch / tw) * size.width()
-            self.buttonMinimize.setGeometry(x, 0, w, size.height())
+            self.buttonMinimize.setGeometry(int(x), 0, int(w), size.height())
             x += w
         if self.buttonMaximize:
             w = (self.mMaxStretch / tw) * size.width()
-            self.buttonMaximize.setGeometry(x, 0, w, size.height())
+            self.buttonMaximize.setGeometry(int(x), 0, int(w), size.height())
             x += w
         if self.buttonClose:
             w = (self.mCloseStretch / tw) * size.width()
-            self.buttonClose.setGeometry(x, 0, w, size.height())
+            self.buttonClose.setGeometry(int(x), 0, int(w), size.height())
 
     def sizeHint(self) -> QSize:
         w = 0


### PR DESCRIPTION
SARibbonContextCategory 这个类没有compare的方法，所以hide的时候会报错，我试了下用 “==“ ”是可以的